### PR TITLE
Resolve white screen error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,12 @@ export default defineConfig({
     emptyOutDir: true,
   },
   server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:5000",
+        changeOrigin: true,
+      },
+    },
     fs: {
       strict: true,
       deny: ["**/.*"],


### PR DESCRIPTION
Add Vite proxy configuration to resolve white screen error.

The white screen error was caused by the frontend being unable to communicate with the backend API due to missing proxy configuration in Vite.